### PR TITLE
モック作成前のレイアウト調整

### DIFF
--- a/sample_app/src/components/core/Top/AppBar/index.tsx
+++ b/sample_app/src/components/core/Top/AppBar/index.tsx
@@ -25,7 +25,7 @@ function ButtonAppBar() {
       <AppBar position="static">
         <Toolbar>
           <Typography variant="h4" className={classes.title}>
-            PigTalk
+            Quiz Realtime
           </Typography>
         </Toolbar>
       </AppBar>

--- a/sample_app/src/components/core/Top/Management/index.tsx
+++ b/sample_app/src/components/core/Top/Management/index.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { Card, CardActions, CardContent, CardHeader, withStyles } from '@material-ui/core';
-import { Button, Divider, FormControl, FormControlLabel, FormLabel, Grid, makeStyles, Radio, RadioGroup, Typography} from '@material-ui/core';
+import {makeStyles} from '@material-ui/core/styles';
+import { Card, CardActions, CardContent, CardHeader } from '@material-ui/core';
+import { Button, Typography} from '@material-ui/core';
 import '../../../../styles/TextInput.css';
+
+const useStyles = makeStyles(theme => ({
+  btn: {
+    marginBottom: "10px"
+  },
+}));
 
 function Management() {
 
@@ -15,43 +22,49 @@ function Management() {
     setOpen(false);
   };
 
+  const classes = useStyles();
 
     return (
+      
       <React.Fragment>
-        <Card　className="root">
+        <Card>
           <CardHeader>
           </CardHeader>
-
           <CardContent>
             <Typography
               // className={classes.title}
               color="textSecondary"
-              gutterBottom
-              variant="h4">
+              variant="h4"
+              align="left"
+              gutterBottom>
               管理画面
             </Typography>
             <Typography
               // className={classes.title}
               color="textSecondary"
-              variant="h5">
+              variant="h6"
+              gutterBottom>
               管理者:
             </Typography>
+            <Button
+              // onClick={() => props.onClick(props.value, props.image)}
+              variant="contained"
+              color="primary"
+              className={classes.btn}
+            >
+              結果を表示
+            </Button>
+            <div>
               <Button
                 // onClick={() => props.onClick(props.value, props.image)}
                 variant="contained"
                 color="primary"
+                className={classes.btn}
               >
-                結果を表示
+                次のクイズへ
               </Button>
-              <Button
-                // onClick={() => props.onClick(props.value, props.image)}
-                variant="contained"
-                color="primary"
-                >
-                  次のクイズへ
-              </Button>
-          </CardContent>
-          
+            </div>
+          </CardContent>          
           <CardActions>
           </CardActions>
         </Card>

--- a/sample_app/src/components/core/Top/Management/index.tsx
+++ b/sample_app/src/components/core/Top/Management/index.tsx
@@ -25,7 +25,6 @@ function Management() {
   const classes = useStyles();
 
     return (
-      
       <React.Fragment>
         <Card>
           <CardHeader>

--- a/sample_app/src/components/core/Top/PlayersList/index.tsx
+++ b/sample_app/src/components/core/Top/PlayersList/index.tsx
@@ -6,6 +6,7 @@ import Divider from '@material-ui/core/Divider';
 import ListItemText from '@material-ui/core/ListItemText';
 import { Star } from '@material-ui/icons'
 import { Favorite } from '@material-ui/icons'
+import { Card, CardContent } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -18,7 +19,7 @@ const useStyles = makeStyles(theme => ({
 
 function RenderIcon(props: any) {
   console.log("auth:" + props.auth)
-  if(props.auth == 'test') { // TODO：プレイヤーの回答権を判定
+  if(props.auth == 'fukunaga') { // TODO：プレイヤーの回答権を判定
     return <Star color="secondary" />;
   } else {
     return <Favorite />;
@@ -26,19 +27,24 @@ function RenderIcon(props: any) {
 }
 
 function PlayersList(props: any) {
-  console.log(props.image);
-  console.log(props.text);
   const classes = useStyles();
   return (
-    <List className={classes.root}>
-      <ListItem alignItems="flex-start">
-        <ListItemText primary={props.text} />
-        <RenderIcon
-          auth={props.text} // TODO：プレイヤーの回答有無を取得
-        />
-      </ListItem>
+    <React.Fragment>
+    <Card>
+      <CardContent>
+      <List className={classes.root}>
+        <ListItem alignItems="flex-start">
+          <ListItemText primary={props.text} />
+          <RenderIcon
+            auth={props.text} // TODO：プレイヤーの回答有無を取得
+          />
+        </ListItem>
       <Divider component="li" />
-    </List>
+      </List>
+    </CardContent>
+    </Card>
+  </React.Fragment>
+
   );
 }
 

--- a/sample_app/src/components/core/Top/PlayersList/index.tsx
+++ b/sample_app/src/components/core/Top/PlayersList/index.tsx
@@ -44,7 +44,6 @@ function PlayersList(props: any) {
     </CardContent>
     </Card>
   </React.Fragment>
-
   );
 }
 

--- a/sample_app/src/components/core/Top/QuizView/index.tsx
+++ b/sample_app/src/components/core/Top/QuizView/index.tsx
@@ -29,6 +29,7 @@ class QuizView extends Component {
     let series = chart.series.push(new am4charts.PieSeries());
     series.dataFields.value = "litres";
     series.dataFields.category = "country";
+    series.labels.template.disabled = true;
     chart.data = [{
       "country": "お好み焼き",
       "litres": 35
@@ -69,7 +70,7 @@ class QuizView extends Component {
             </Typography>
             <Divider component="div" />
             <ProgressBar />
-            <div id="chartdiv" style={{ width: "100%", height: "500px" }}></div>
+            <div id="chartdiv" style={{ width: "100%", height: "500px"}}></div>
             <Typography variant="body2" component="p">
             </Typography>
             <Divider component="p" />

--- a/sample_app/src/components/core/Top/QuizView/index.tsx
+++ b/sample_app/src/components/core/Top/QuizView/index.tsx
@@ -70,7 +70,7 @@ class QuizView extends Component {
             </Typography>
             <Divider component="div" />
             <ProgressBar />
-            <div id="chartdiv" style={{ width: "100%", height: "500px"}}></div>
+            <div id="chartdiv" style={{ width: "100%", height: "500px" }}></div>
             <Typography variant="body2" component="p">
             </Typography>
             <Divider component="p" />

--- a/sample_app/src/templates/Top/Main/index.tsx
+++ b/sample_app/src/templates/Top/Main/index.tsx
@@ -27,26 +27,18 @@ class Main extends Component<{}, State> {
     return (<div className="a__top-main">
       <Top.ButtonAppBar />
       <div className="b__top-main">
-        <Grid container spacing={3} alignItems="center" justify="center">
+        <Grid container spacing={3} alignItems="stretch" justify="center">
           <Grid item xs={4}>
             {this.players.map((player) => ( 
               <Top.PlayersList image={player['image']} text={player['text']} />
             ))}
           </Grid>
           <Grid item xs={4}>
-            <Top.TextInput
-            // onChange={(this.props as any).actions.messages.change}
-            // context={(this.props as any).messages.value}
-            />
-          </Grid>
-          <Grid item xs={4}>
             <Top.QuizView />
-            <Top.Template />
           </Grid>
           <Grid item xs={4}>
             <Top.Management />
           </Grid>
-          <Top.QuizDescription />
         </Grid>
         {/* {(this.props as any).messages.msgs.map((m: any, i: any) => (<Top.AlignItemsList key={i} msgs={m} />))} */}
         {/* <Top.SendButton onClick={(this.props as any).actions.messages.submit} value={(this.props as any).messages.value} image={(this.props as any).messages.image} /> */}


### PR DESCRIPTION
<img width="1792" alt="スクリーンショット 2021-03-25 19 04 14" src="https://user-images.githubusercontent.com/54831932/112456247-ebc6fa80-8d9d-11eb-8b7f-1234a39b3210.png">

画面中央のチャートで文字が溢れてしまうという状態を解消できなかったので、
https://www.amcharts.com/docs/v4/chart-types/pie-chart/#Disabling_various_elements
を参考に、文字を消しています。

https://github.com/2020-hs-c-team/team_c_react_typescript/pull/12/files#diff-ac5a3861e2b8608159bbe2d5c9f1389a0686c3a59294cf1ce8c365e0d441df4fR32